### PR TITLE
Fix inadvertent usage of BSL license

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains Blast's fork of optimism and op-geth. This initial release is
 ## Running Blast locally (against a local L1)
 
 ### Prereqs
-`docker`, `git`, `go1.20`, `node`, `pnpm`, `foundry`, `make`, `yarn`, `direnv`
+`docker`, `git`, `go1.20`, `node`, `pnpm`, `foundry`, `make`, `yarn`, `direnv`, `jq`
 
 ### Steps
 

--- a/blast-optimism/LICENSE
+++ b/blast-optimism/LICENSE
@@ -1,41 +1,22 @@
-Business Source License 1.1
-License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved. "Business Source License" is a trademark of MariaDB Corporation Ab.
+(The MIT License)
 
-Parameters
+Copyright 2024 MetaLayer Labs, Ltd.
 
-Licensor: MetaLayer Labs, Ltd.
-Licensed Work: Blast Network. The Licensed Work is (c) 2024 MetaLayer Labs, Ltd.
-Additional Use Grant: None.
-Change Date: January 29, 2028.
-Change License: GNU General Public License v3.0 or later.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-Terms
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-The Licensor hereby grants you the right to copy, modify, create derivative works, redistribute, and make non-production use of the Licensed Work. The Licensor may make an Additional Use Grant, above, permitting limited production use.
-
-Effective on the Change Date, or the fourth anniversary of the first publicly available distribution of a specific version of the Licensed Work under this License, whichever comes first, the Licensor hereby grants you rights under the terms of the Change License, and the rights granted in the paragraph above terminate.
-If your use of the Licensed Work does not comply with the requirements currently in effect as described in this License, you must purchase a commercial license from the Licensor, its affiliated entities, or authorized resellers, or you must refrain from using the Licensed Work.
-
-All copies of the original and modified Licensed Work, and derivative works of the Licensed Work, are subject to this License. This License applies separately for each version of the Licensed Work and the Change Date may vary for each version of the Licensed Work released by Licensor.
-
-You must conspicuously display this License on each original or modified copy of the Licensed Work. If you receive the Licensed Work in original or modified form from a third party, the terms and conditions set forth in this License apply to your use of that work.
-
-Any use of the Licensed Work in violation of this License will automatically terminate your rights under this License for the current and all other versions of the Licensed Work.
-
-This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may use a trademark or logo of Licensor as expressly required by this License).
-
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
-
-MariaDB hereby grants you permission to use this LicenseÕs text to license your works, and to refer to it using the trademark "Business Source License", as long as you comply with the Covenants of Licensor below.
-
-Covenants of Licensor
-
-In consideration of the right to use this LicenseÕs text and the "Business Source License" name and trademark, Licensor covenants to MariaDB, and to all other recipients of the licensed work to be provided by Licensor:
-1. To specify as the Change License the GPL Version 2.0 or any later version, or a license that is compatible with GPL Version 2.0 or a later version, where "compatible" means that software provided under the Change License can be included in a program with software provided under GPL Version 2.0 or a later version. Licensor may specify additional Change Licenses without limitation.
-2. To either: (a) specify an additional grant of rights to use that does not impose any additional restriction on the right granted in this License, as the Additional Use Grant; or (b) insert the text "None".
-3. To specify a Change Date.
-4. Not to modify this License in any other way.
-
-Notice
-
-The Business Source License (this document, or the "License") is not an Open Source license. However, the Licensed Work will eventually be made available under an Open Source License, as stated in this License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/blast-optimism/packages/contracts-bedrock/src/EAS/Common.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/EAS/Common.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 // A representation of an empty/uninitialized UID.

--- a/blast-optimism/packages/contracts-bedrock/src/EAS/EAS.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/EAS/EAS.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/EAS/IEAS.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/EAS/IEAS.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { ISchemaRegistry } from "src/EAS/ISchemaRegistry.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/EAS/ISchemaRegistry.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/EAS/ISchemaRegistry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { ISchemaResolver } from "src/EAS/resolver/ISchemaResolver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/EAS/SchemaRegistry.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/EAS/SchemaRegistry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
 import { ISemver } from "src/universal/ISemver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/EAS/eip1271/EIP1271Verifier.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/EAS/eip1271/EIP1271Verifier.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/EAS/resolver/ISchemaResolver.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/EAS/resolver/ISchemaResolver.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { Attestation } from "../Common.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/EAS/resolver/SchemaResolver.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/EAS/resolver/SchemaResolver.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
 import { Semver } from "../../universal/Semver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L1/DelayedVetoable.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L1/DelayedVetoable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ISemver } from "src/universal/ISemver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ERC721Bridge } from "src/universal/ERC721Bridge.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L1/OptimismPortal.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L1/OptimismPortal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L1/ResourceMetering.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L1/ResourceMetering.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/BaseFeeVault.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/BaseFeeVault.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ISemver } from "src/universal/ISemver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/CrossDomainOwnable.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/CrossDomainOwnable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/CrossDomainOwnable2.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/CrossDomainOwnable2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/CrossDomainOwnable3.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/CrossDomainOwnable3.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/ERC20PermitUpgradeable.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/ERC20PermitUpgradeable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.9.0) (token/ERC20/extensions/ERC20Permit.sol)
 
 pragma solidity ^0.8.0;

--- a/blast-optimism/packages/contracts-bedrock/src/L2/ERC20Rebasing.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/ERC20Rebasing.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ISemver } from "src/universal/ISemver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ISemver } from "src/universal/ISemver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/L1FeeVault.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/L1FeeVault.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ISemver } from "src/universal/ISemver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/L2ERC721Bridge.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/L2ERC721Bridge.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ERC721Bridge } from "src/universal/ERC721Bridge.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Types } from "src/libraries/Types.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/SequencerFeeVault.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/SequencerFeeVault.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ISemver } from "src/universal/ISemver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/Shares.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/Shares.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/USDB.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/USDB.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/L2/WETHRebasing.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L2/WETHRebasing.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { FixedPointMathLib } from "solmate/utils/FixedPointMathLib.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/Safe/LivenessGuard.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/Safe/LivenessGuard.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Safe } from "safe-contracts/Safe.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/Safe/LivenessModule.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/Safe/LivenessModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Safe, OwnerManager } from "safe-contracts/Safe.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/Safe/SafeSigners.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/Safe/SafeSigners.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 library SafeSigners {

--- a/blast-optimism/packages/contracts-bedrock/src/cannon/MIPS.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/cannon/MIPS.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { IPreimageOracle } from "./interfaces/IPreimageOracle.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/cannon/PreimageKeyLib.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/cannon/PreimageKeyLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 /// @title PreimageKeyLib

--- a/blast-optimism/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { IPreimageOracle } from "./interfaces/IPreimageOracle.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/cannon/interfaces/IPreimageOracle.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/cannon/interfaces/IPreimageOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 /// @title IPreimageOracle

--- a/blast-optimism/packages/contracts-bedrock/src/cannon/libraries/CannonErrors.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/cannon/libraries/CannonErrors.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 /// @notice Thrown when a passed part offset is out of bounds.

--- a/blast-optimism/packages/contracts-bedrock/src/dispute/BlockOracle.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/dispute/BlockOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import "src/libraries/DisputeTypes.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 import { ClonesWithImmutableArgs } from "@cwia/ClonesWithImmutableArgs.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/dispute/interfaces/IBigStepper.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/dispute/interfaces/IBigStepper.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/dispute/interfaces/IBondManager.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/dispute/interfaces/IBondManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 /// @title IBondManager

--- a/blast-optimism/packages/contracts-bedrock/src/dispute/interfaces/IDisputeGame.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/dispute/interfaces/IDisputeGame.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 import { IBondManager } from "./IBondManager.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/dispute/interfaces/IDisputeGameFactory.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/dispute/interfaces/IDisputeGameFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 import { IDisputeGame } from "./IDisputeGame.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/dispute/interfaces/IFaultDisputeGame.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/dispute/interfaces/IFaultDisputeGame.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 import { IDisputeGame } from "./IDisputeGame.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/dispute/interfaces/IInitializable.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/dispute/interfaces/IInitializable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 /// @title IInitializable

--- a/blast-optimism/packages/contracts-bedrock/src/dispute/lib/LibClock.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/dispute/lib/LibClock.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 import "src/libraries/DisputeTypes.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/dispute/lib/LibGameId.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/dispute/lib/LibGameId.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 import "src/libraries/DisputeTypes.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/dispute/lib/LibHashing.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/dispute/lib/LibHashing.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 import "src/libraries/DisputeTypes.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/dispute/lib/LibPosition.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/dispute/lib/LibPosition.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 import "src/libraries/DisputeTypes.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/governance/GovernanceToken.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/governance/GovernanceToken.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/governance/MintManager.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/governance/MintManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/legacy/AddressManager.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/legacy/AddressManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/legacy/DeployerWhitelist.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/legacy/DeployerWhitelist.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ISemver } from "src/universal/ISemver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/legacy/L1BlockNumber.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/legacy/L1BlockNumber.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { L1Block } from "src/L2/L1Block.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Constants } from "src/libraries/Constants.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/legacy/LegacyERC20ETH.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/legacy/LegacyERC20ETH.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/legacy/LegacyMessagePasser.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/legacy/LegacyMessagePasser.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ISemver } from "src/universal/ISemver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/legacy/LegacyMintableERC20.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/legacy/LegacyMintableERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { AddressManager } from "src/legacy/AddressManager.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/Arithmetic.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/Arithmetic.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { SignedMath } from "@openzeppelin/contracts/utils/math/SignedMath.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/Burn.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/Burn.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 /// @title Burn

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/Bytes.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/Bytes.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /// @title Bytes

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/Constants.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/Constants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { ResourceMetering } from "../L1/ResourceMetering.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/DisputeErrors.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/DisputeErrors.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 import "./DisputeTypes.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/DisputeTypes.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/DisputeTypes.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
 import { LibHashing } from "../dispute/lib/LibHashing.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/Encoding.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/Encoding.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { Types } from "./Types.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/Hashing.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/Hashing.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { Types } from "./Types.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/LegacyCrossDomainUtils.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/LegacyCrossDomainUtils.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
 // Importing from the legacy contracts package causes issues with the build of the contract bindings

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /// @title Predeploys

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/SafeCall.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/SafeCall.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 /// @title SafeCall

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/Storage.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/Storage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /// @title Storage

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/Types.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/Types.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /// @title Types

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/rlp/RLPReader.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/rlp/RLPReader.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 /// @custom:attribution https://github.com/hamdiallam/Solidity-RLP

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/rlp/RLPWriter.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/rlp/RLPWriter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /// @custom:attribution https://github.com/bakaoh/solidity-rlp-encode

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/trie/MerkleTrie.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/trie/MerkleTrie.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { Bytes } from "../Bytes.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/libraries/trie/SecureMerkleTrie.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/libraries/trie/SecureMerkleTrie.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { MerkleTrie } from "./MerkleTrie.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/DelegateCalls.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/DelegateCalls.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 interface IDelegateCalls {

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/ETHYieldManager.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/ETHYieldManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { YieldManager } from "src/mainnet-bridge/YieldManager.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/Insurance.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/Insurance.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/L1BlastBridge.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/L1BlastBridge.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/L2BlastBridge.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/L2BlastBridge.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/USDConversions.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/USDConversions.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/USDYieldManager.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/USDYieldManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/YieldManager.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/YieldManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/yield-providers/DSRYieldProvider.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/yield-providers/DSRYieldProvider.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { FixedPointMathLib } from "solmate/utils/FixedPointMathLib.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/yield-providers/ETHTestnetYieldProvider.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/yield-providers/ETHTestnetYieldProvider.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/yield-providers/LidoYieldProvider.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/yield-providers/LidoYieldProvider.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/yield-providers/TestnetYieldProvider.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/yield-providers/TestnetYieldProvider.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/yield-providers/USDTestnetYieldProvider.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/yield-providers/USDTestnetYieldProvider.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/yield-providers/YieldProvider.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/mainnet-bridge/yield-providers/YieldProvider.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { YieldManager } from "src/mainnet-bridge/YieldManager.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/AssetReceiver.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/AssetReceiver.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/Transactor.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/Transactor.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { Owned } from "@rari-capital/solmate/src/auth/Owned.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/TransferOnion.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/TransferOnion.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/drippie/Drippie.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/drippie/Drippie.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { AssetReceiver } from "../AssetReceiver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/drippie/IDripCheck.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/drippie/IDripCheck.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IDripCheck {

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckBalanceHigh.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckBalanceHigh.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { IDripCheck } from "../IDripCheck.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckBalanceLow.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckBalanceLow.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { IDripCheck } from "../IDripCheck.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckGelatoLow.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckGelatoLow.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { IDripCheck } from "../IDripCheck.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckTrue.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckTrue.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { IDripCheck } from "../IDripCheck.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { IFaucetAuthModule } from "./authmodules/IFaucetAuthModule.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/faucet/authmodules/IFaucetAuthModule.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/faucet/authmodules/IFaucetAuthModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Faucet } from "../Faucet.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/op-nft/AttestationStation.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/op-nft/AttestationStation.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Semver } from "../../universal/Semver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/op-nft/Optimist.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/op-nft/Optimist.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Semver } from "../../universal/Semver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/op-nft/OptimistAllowlist.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/op-nft/OptimistAllowlist.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Semver } from "../../universal/Semver.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/op-nft/OptimistInviter.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/op-nft/OptimistInviter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { OptimistConstants } from "./libraries/OptimistConstants.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/periphery/op-nft/libraries/OptimistConstants.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/periphery/op-nft/libraries/OptimistConstants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 /// @title  OptimistConstants

--- a/blast-optimism/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/universal/ERC721Bridge.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/ERC721Bridge.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { CrossDomainMessenger } from "src/universal/CrossDomainMessenger.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/universal/FeeVault.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/FeeVault.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { L2StandardBridge } from "src/L2/L2StandardBridge.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/universal/IOptimismMintableERC20.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/IOptimismMintableERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/universal/IOptimismMintableERC721.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/IOptimismMintableERC721.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/universal/ISemver.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/ISemver.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /// @title ISemver

--- a/blast-optimism/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/universal/OptimismMintableERC721.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/OptimismMintableERC721.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/universal/OptimismMintableERC721Factory.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/OptimismMintableERC721Factory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { OptimismMintableERC721 } from "src/universal/OptimismMintableERC721.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/universal/Proxy.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/Proxy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Constants } from "src/libraries/Constants.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/universal/ProxyAdmin.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/ProxyAdmin.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/universal/Semver.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/Semver.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/universal/StandardBridge.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/StandardBridge.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/blast-optimism/packages/contracts-bedrock/src/universal/StorageSetter.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/universal/StorageSetter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSL 1.1 - Copyright 2024 MetaLayer Labs Ltd.
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
 import { ISemver } from "src/universal/ISemver.sol";


### PR DESCRIPTION
It appears the license on the contracts forked from the Optimism Foundation was inadvertently changed to the Business Source License (BSL) from the MIT license.

This PR reverts that change, setting the SPDX-Identifier on the `.sol` files back to MIT.