### PR TITLE
2 Fixes: An attempt to access a variable that has not been declared yet and a check that always returns an error.

### DIFF
--- a/blast-optimism/op-chain-ops/cmd/check-l2/main.go
+++ b/blast-optimism/op-chain-ops/cmd/check-l2/main.go
@@ -913,7 +913,7 @@ func checkUSDB(addr common.Address, client *ethclient.Client) error {
 	if err != nil {
 		return err
 	}
-	if price != 18 {
+	if decimals != 18 {
 		return fmt.Errorf("Decimals is incorrect")
 	}
 	log.Info("USDB", "decimals", decimals)
@@ -975,7 +975,7 @@ func checkWETHRebasing(addr common.Address, client *ethclient.Client) error {
 	if err != nil {
 		return err
 	}
-	if price != 18 {
+	if decimals != 18 {
 		return fmt.Errorf("Decimals is incorrect")
 	}
 	log.Info("WETHRebasing", "decimals", decimals)


### PR DESCRIPTION
Inside the functions `checkUSDB` and `checkWETHRebasing` of `blast-optimism/op-chain-ops/cmd/check-l2/main.go`, instead of checking the decimals to be equal to `18`, we enforce the `price` of the token to be equal to `18`.
```go
	decimals, err := contract.Decimals(&bind.CallOpts{}) // This line reads the decimals
	if err != nil {
		return err
	}
	if price != 18 { // This line should compare the value of decimals with 18, but instead compares the price
		return fmt.Errorf("Decimals is incorrect")
	}
```

Additionally, we attempt to access the value of the variable "price" several lines of code before we declare it.
```go
	if price != 18 { // <- We try to access the value of "price" here
		return fmt.Errorf("Decimals is incorrect")
	}
	log.Info("USDB", "decimals", decimals)

	price, err := contract.Price(&bind.CallOpts{}) // <- Here is were we declare "price"
```


This pull request fixes all of the above.