### PR TITLE
Fix typo: blockshashes -> blockhashes

### DIFF
--- a/blast-geth/cmd/evm/README.md
+++ b/blast-geth/cmd/evm/README.md
@@ -16,7 +16,7 @@ which can
 1. Take a prestate, including
   - Accounts,
   - Block context information,
-  - Previous blockshashes (*optional)
+  - Previous blockhashes (*optional)
 2. Apply a set of transactions,
 3. Apply a mining-reward (*optional),
 4. And generate a post-state, including


### PR DESCRIPTION
## Summary
- Fixed typo in EVM tool documentation: "blockshashes" -> "blockhashes"

## Test plan
- No testing required - documentation change only