### PR TITLE
Fix typo: usecases -> use cases

### DIFF
--- a/blast-geth/cmd/clef/rules.md
+++ b/blast-geth/cmd/clef/rules.md
@@ -2,7 +2,7 @@
 
 The `signer` binary contains a ruleset engine, implemented with [OttoVM](https://github.com/robertkrimen/otto)
 
-It enables usecases like the following:
+It enables use cases like the following:
 
 * I want to auto-approve transactions with contract `CasinoDapp`, with up to `0.05 ether` in value to maximum `1 ether` per 24h period
 * I want to auto-approve transaction to contract `EthAlarmClock` with `data`=`0xdeadbeef`, if `value=0`, `gas < 44k` and `gasPrice < 40Gwei`


### PR DESCRIPTION
## Summary
- Fixed typo in Clef rules documentation: "usecases" -> "use cases"

## Test plan
- No testing required - documentation change only