### PR TITLE
Fix typo: occured -> occurred

### DIFF
--- a/blast-geth/miner/worker.go
+++ b/blast-geth/miner/worker.go
@@ -569,7 +569,7 @@ func (w *worker) mainLoop() {
 			func() {
 				defer func() {
 					if err := recover(); err != nil {
-						log.Error("programmer error panic occured during main loop transaction", "panic", err)
+						log.Error("programmer error panic occurred during main loop transaction", "panic", err)
 					}
 				}()
 				// Apply transactions to the pending state if we're not sealing
@@ -1128,7 +1128,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 func (w *worker) fillTransactions(interrupt *atomic.Int32, env *environment) error {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Error("programmer error panic occured during fill transaction", "panic", err)
+			log.Error("programmer error panic occurred during fill transaction", "panic", err)
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- Fixed typo in miner worker.go error messages: "occured" -> "occurred" (2 instances)

## Test plan
- No testing required - error message change only