### PR TITLE
Fix typo: seperated -> separated

### DIFF
--- a/blast-optimism/packages/sdk/test-next/README.md
+++ b/blast-optimism/packages/sdk/test-next/README.md
@@ -1,5 +1,5 @@
 # test-next
 
 - The new tests for the next version of sdk will use vitest
-- The vitest tests are kept here seperated from mocha tests for now
+- The vitest tests are kept here separated from mocha tests for now
 - Can find values needed in a `.env` file in `example.env`


### PR DESCRIPTION
## Summary
- Fixed typo in SDK test-next README: "seperated" -> "separated"

## Test plan
- No testing required - documentation change only