### PR TITLE
Fix typo: transfering -> transferring in L1StandardBridge

### DIFF
--- a/blast-optimism/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
+++ b/blast-optimism/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
@@ -10,7 +10,7 @@ import { Constants } from "src/libraries/Constants.sol";
 
 /// @custom:proxied
 /// @title L1StandardBridge
-/// @notice The L1StandardBridge is responsible for transfering ETH and ERC20 tokens between L1 and
+/// @notice The L1StandardBridge is responsible for transferring ETH and ERC20 tokens between L1 and
 ///         L2. In the case that an ERC20 token is native to L1, it will be escrowed within this
 ///         contract. If the ERC20 token is native to L2, it will be burnt. Before Bedrock, ETH was
 ///         stored within this contract. After Bedrock, ETH is instead stored inside the


### PR DESCRIPTION
## Summary
- Fixed typo in L1StandardBridge.sol natspec comment: "transfering" -> "transferring"

## Test plan
- No testing required - comment change only